### PR TITLE
Cvpartner export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ ci/.zip
 ui/resources/public/js/
 /ui/figwheel-main.edn
 /ui/icons
+/.envrc
+/secret.envrc

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ ui/resources/public/js/
 /ui/icons
 /.envrc
 /secret.envrc
+/cvpartner.error.txt

--- a/README.md
+++ b/README.md
@@ -561,6 +561,29 @@ ellers vil Ansible feile når det forsøkes å bestille sertifikat, ettersom
 den prosessen krever at serveren du er på er tilgjengelig over internett
 med det hostnamet du bestiller sertifikat for.
 
+## Eksporter cv-er til cvpartner.no
+Kjør følgende script og følg oppskriften du får. 
+
+```sh
+./cvpartner-export.sh
+```
+
+Du vil bli bedt om å opprette filen `secret.envrc` fra malen `secret-sample.envrc` 
+og legge inn cvpartner api token i denne. Og så må du source denne: 
+```sh
+. ./secret.envrc
+```
+
+Eller du kan bruke [direnv](https://direnv.net/) for å source den automatisk (anbefalt).
+
+Når du er ferdig satt opp kan du eksportere én og én eller alle:
+```sh
+./cvpartner-export.sh kolbjorn gry stian 
+./cvpartner-export.sh all
+```
+ 
+> Husk å gjør `git pull` for å få med siste endringer på cv-er!
+
 ## Bidra til koden
 
 Supert! Gjør gjerne det, men husk å kjøre testene:

--- a/build.sh
+++ b/build.sh
@@ -25,8 +25,6 @@ prod-env() {
 bucket="s3://kodemaker-www/"
 target="build"
 
-if [-f ]
-
 echo "Syncing down production site for accurate build diffs"
 mkdir -p "$target"
 pushd "$target" > /dev/null

--- a/build.sh
+++ b/build.sh
@@ -25,6 +25,8 @@ prod-env() {
 bucket="s3://kodemaker-www/"
 target="build"
 
+if [-f ]
+
 echo "Syncing down production site for accurate build diffs"
 mkdir -p "$target"
 pushd "$target" > /dev/null

--- a/cvpartner-export.sh
+++ b/cvpartner-export.sh
@@ -6,6 +6,13 @@ if [ ! -f ./secret.envrc ]; then
   exit
 fi
 
+if [ -z "${CVPARTNER_AUTHORIZATION_TOKEN}" ] ||
+   [ "${CVPARTNER_AUTHORIZATION_TOKEN}" == "hemmelig" ]; then
+  echo "Miljøvariabel CVPARTNER_AUTHORIZATION_TOKEN er ikke satt opp"
+  echo "Følg beskrivelsen i filen  ./secret-sample.envrc"
+  exit
+fi
+
 if [ $# -eq 0 ]; then
   echo "Usage: $0 [<name-as-in-email>* | 'all']"
   echo "Example: $0 kolbjorn"

--- a/cvpartner-export.sh
+++ b/cvpartner-export.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+if [ ! -f ./secret.envrc ]; then
+  echo "Cvpartner authorization token er ikke satt opp."
+  echo "Følg beskrivelsen i filen  ./secret-sample.envrc"
+  exit
+fi
+
+if [ $# -eq 0 ]; then
+  echo "Usage: $0 [<name-as-in-email>* | 'all']"
+  echo "Example: $0 kolbjorn"
+  exit
+fi
+
+echo ""
+echo "Generering av cv-er fra kodemaker.no til cvpartner.no startet..."
+echo "Du kan følge med på genereringen på http://kodemaker.cvpartner.no :)"
+echo ""
+
+lein cvpartner-export $*

--- a/cvpartner-export.sh
+++ b/cvpartner-export.sh
@@ -17,4 +17,4 @@ echo "Generering av cv-er fra kodemaker.no til cvpartner.no startet..."
 echo "Du kan følge med på genereringen på http://kodemaker.cvpartner.no :)"
 echo ""
 
-lein cvpartner-export $*
+lein cvpartner-export $* 2>cvpartner.error.txt

--- a/project.clj
+++ b/project.clj
@@ -35,7 +35,8 @@
          :init repl/init-app-for-ring!
          :port 3334}
   :aliases {"build-site" ["run" "-m" "kodemaker-no.web/export"]
-            "build-new-site" ["run" "-m" "kodemaker-no.web/export-new"]}
+            "build-new-site" ["run" "-m" "kodemaker-no.web/export-new"]
+            "cvpartner-export" ["run" "-m" "kodemaker-no.export.cvpartner/cvpartner-export"]}
   :profiles {:dev {:dependencies [[hiccup-find  "1.0.0"]
                                   [integrant "0.7.0"]
                                   [integrant/repl "0.3.1"]

--- a/project.clj
+++ b/project.clj
@@ -26,7 +26,9 @@
                  [datomic-type-extensions "2019-09-04"]
                  [java-time-dte "2018-04-18"]
                  [java-time-literals "2018-04-06"]
-                 [html5-walker "2020-01-08"]]
+                 [html5-walker "2020-01-08"]
+                 [clj-http "3.10.1"]
+                 [cheshire "5.10.0"]]
   :jvm-opts ["-Xmx768M"
              "-Djava.awt.headless=true"]
   :ring {:handler repl/ring-app

--- a/project.clj
+++ b/project.clj
@@ -51,5 +51,5 @@
                              [lein-ancient "0.6.15"]
                              [lein-midje "3.2.1"]]
                    :source-paths ["dev" "config" "ui/src"]
-                   :resource-paths ["ui/resources"]
+                   :resource-paths ["ui/resources" "test/resources"]
                    :test-paths ["test"]}})

--- a/secret-sample.envrc
+++ b/secret-sample.envrc
@@ -1,6 +1,5 @@
 # Copy this file to secret.envrc and replace secret(s) as told below.
-# Source secret.envrc from the shell, or consider using `direnv` for automatic loading.
-# NOTE For now only used with cpvpartner-export.sh script.
+# Then, source secret.envrc from the shell, or consider using direnv for automatic sourcing.
 
 # cvpartner authorization token er hemmelig, men du finner den her:
 #   https://docs.google.com/spreadsheets/d/1oZOVqwcbc6C0ctM2lneC0rYmFd5RPTFenKby_41eiEA/edit#gid=0

--- a/secret-sample.envrc
+++ b/secret-sample.envrc
@@ -1,0 +1,7 @@
+# Copy this file to secret.envrc and replace secret(s) as told below.
+# Source secret.envrc from the shell, or consider using `direnv` for automatic loading.
+# NOTE For now only used with cpvpartner-export.sh script.
+
+# cvpartner authorization token er hemmelig, men du finner den her:
+#   https://docs.google.com/spreadsheets/d/1oZOVqwcbc6C0ctM2lneC0rYmFd5RPTFenKby_41eiEA/edit#gid=0
+export CVPARTNER_AUTHORIZATION_TOKEN=hemmelig

--- a/src/kodemaker_no/content.clj
+++ b/src/kodemaker_no/content.clj
@@ -25,7 +25,7 @@
        (map (juxt :id identity))
        (into {})))
 
-(defn- slurp-edn-map [file]
+(defn slurp-edn-map [file]
   (read-string-strictly [file (slurp file)]))
 
 (defn load-content []

--- a/src/kodemaker_no/export/cvpartner.clj
+++ b/src/kodemaker_no/export/cvpartner.clj
@@ -310,7 +310,8 @@
                (update-cv cv)))
          (println "  Successfully created cv for " email)
          (catch Exception e
-           (println "==> Failed creating cv for" email ": " e)
+           (println "==> Failed creating cv for" email ". See error file for details.")
+           (.println *err* (str "==> Failed creating cv for " email ": " e))
            ;(println "Person data is:" person)
            ;(println "Generated cv is:" cv)
            ))))

--- a/src/kodemaker_no/export/cvpartner.clj
+++ b/src/kodemaker_no/export/cvpartner.clj
@@ -8,8 +8,7 @@
             [kodemaker-no.atomic :as atomic]
             [kodemaker-no.ingest :as ingest]
             [kodemaker-no.new-pages.cv-page :as page]
-            [kodemaker-no.new-pages.person :refer [prefer-techs]]
-            [repl])
+            [kodemaker-no.new-pages.person :refer [prefer-techs]])
   (:import java.time.LocalDate))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -26,10 +25,10 @@
   (d/pull db '[*] id))
 
 (defn- find-all-person-ids [db]
-  (map #(first %1) (d/q '[:find ?e :where [?e :person/email-address]] db)))
+  (d/q '[:find [?e ...] :where [?e :person/email-address]] db))
 
 (defn- find-person-by-email [db email]
-  (db-pull-by-id db (first (first (d/q '[:find ?e :in $ ?email :where [?e :person/email-address ?email]] db email)))))
+  (db-pull-by-id db (d/q '[:find ?e . :in $ ?email :where [?e :person/email-address ?email]] db email)))
 
 (defn- find-all-people [db]
   (->> (find-all-person-ids db)
@@ -325,7 +324,7 @@
           company-config (get-company-config)
           people (if (some #{"all"} names)
                    (->> (find-all-people db)
-                        (filter #(not (:person/quit? %)))
+                        (remove :person/quit?)
                         (filter :person/profile-active?)
                         ;(drop 12)                           ; TODO testing
                         ;(take 2)                            ; TODO testing

--- a/src/kodemaker_no/export/cvpartner.clj
+++ b/src/kodemaker_no/export/cvpartner.clj
@@ -225,7 +225,7 @@
      :technology_skills (map (fn [tech] {:tags {:no (:tech/name tech)}}) techs)}))
 
 
-(defn- generate-cv [db person]
+(defn generate-cv [db person]
   {:telefon             (:person/phone-number person)
    :twitter             (:twitter (:person/presence person))
    :certifications      (map generate-certification (:person/certifications person))

--- a/src/kodemaker_no/export/cvpartner.clj
+++ b/src/kodemaker_no/export/cvpartner.clj
@@ -1,0 +1,217 @@
+(ns kodemaker-no.export.cvpartner
+  (:require [clj-http.client :as http]
+            [cheshire.core :refer :all]
+            [datomic-type-extensions.api :as d]
+            [clojure.string :as str]))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; config stuff
+
+(def authorization-token "hemmelig api key til cvpartner")
+(def site "https://kodemaker.cvpartner.com")
+
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; datomic stuff
+
+(defn- db-pull-by-id [db id]
+  (d/pull db '[*] id))
+
+(defn- find-all-person-ids [db]
+  (map #(first %1) (d/q '[:find ?e :where [?e :person/full-name]] db)))
+
+(defn- find-all-persons [db]
+  (->> (find-all-person-ids db)
+       (map (partial db-pull-by-id db))))
+
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; api stuff
+
+(def authorization-header {"Authorization" (str "Token token=" authorization-token)})
+
+(def api
+  {:companies           (str site "/api/v1/countries")
+   :users               (str site "/api/v1/users")
+   :cvs                 (fn [user-id cv-id] (str/join "/" [site "api/v3/cvs" user-id cv-id]))
+   :project-experiences (fn [user-id cv-id project-id] (str/join "/" [site "api/v3/cvs" user-id cv-id "project_experiences" project-id]))
+   :import-json         (fn [user-id cv-id] (str/join "/" [site "api/v1/cvs" user-id cv-id "import_json"]))})
+
+(defn- post-multipart [_url body]
+  "Really a specialized version for posting cvs to the import_json api.
+  Worked around a bug? in clj-http and/or apache-httpclient to be able to set filename
+  when content is not a file."
+  (let [byteArray (.getBytes (generate-string body))
+        url _url
+        ;url "http://localhost:8080"                        ; see what we send with: >$ nc -l 8080
+        ]
+    (http/post url {:as        :json
+                    :multipart [{:name      "json[file]"
+                                 :mime-type "application/json"
+                                 :encoding  "UTF-8"
+                                 :content   byteArray}]
+                    :headers   authorization-header})))
+
+
+(defn- http-get [url]
+  (:body (http/get url {:as :json :headers authorization-header})))
+
+(defn- http-post [body url]
+  (let [json-body (generate-string body)]
+    (:body (http/post url {:as :json :content-type :json :body json-body :headers authorization-header}))))
+
+(defn- http-delete [url]
+  (http/delete url {:headers authorization-header}))
+
+(defn- http-get-or-nil [url]
+  (let [response (http/get url {:as :json :headers authorization-header :throw-exceptions false})
+        status (:status response)]
+    (cond
+      (<= 200 status 299) (:body response)
+      (= 404 status) nil
+      :else (do
+              (prn (str "Failed while getting url " url))
+              (prn response)
+              (throw (Exception. "Error"))))))
+
+(defn- find-user-by-email [email]
+  (http-get-or-nil (str (api :users) "/find?email=" email)))
+
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; cv cleanup stuff
+
+(defn- delete-all-project-experience [user-id cv-id]
+  (let [cvp-cv (http-get ((api :cvs) user-id cv-id))]
+    ;(run! (partial delete-project-experience user-id cv-id) (:project_experiences cvp-cv)))
+    (doseq [project (:project_experiences cvp-cv)]
+      (http-delete ((api :project-experiences) user-id cv-id (:_id project))))))
+
+(defn- cleanup-cv [cvp-user]
+  "The api is so constructed that one must manually remove cv, one part at a time"
+  (let [cvp-cv (http-get ((api :cvs) (:user_id cvp-user) (:default_cv_id cvp-user)))]
+    (prn "Cleaning up cv for " (:email cvp-user))
+    (do
+      ; + many more deletes
+      (delete-all-project-experience (:user_id cvp-user) (:default_cv_id cvp-user)))))
+
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; cv data generation stuff
+
+(defn- generate-tech [tech]
+  {:tags {:no (:tech/name tech)}})
+
+(defn- generate-project-experience-skills [db project]
+  (let [tech-refs (:project/techs project)
+        techs (map #(db-pull-by-id db (:db/id %)) tech-refs)]
+    (map generate-tech techs)))
+
+
+(defn- generate-project [db project]
+  {:customer                  {:no (:project/customer project)}
+   :description               {:no (:project/summary project)}
+   :long_description          {:no (:project/description project)}
+   :year_from                 (first (:project/years project))
+   :year_to                   (last (:project/years project))
+   :project_experience_skills (generate-project-experience-skills db project)
+   :disabled                  false})
+
+
+(defn- generate-cv [db person]
+  {:project_experiences (map (partial generate-project db) (:person/projects person))})
+
+(defn- generate-user [person company-config]
+  {:country_id (:country-id company-config)
+   :company_id (:company-id company-config)
+   :office_id  (:office-id company-config)
+   :email      (:person/email-address person)
+   :deactivate false
+   :role       "internationalmanager"
+   :name       (:person/full-name person)})
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; Basic logic
+
+(defn- get-company-config []
+  (let [companies (http-get (api :companies))
+        kodemaker (first companies)                         ; We have access to only one company
+        country-id (:country_id (first (:offices kodemaker)))]
+    {:country-id country-id
+     :company-id "5ea83fbf0d5a2501a3ea8ce2"                 ; from another user?
+     :office-id  "5ea83fcb9039f30e1ce2047d"}))              ; from another user?
+
+(defn create-or-update-user [user]
+  (http-post {:user user} (api :users)))
+
+(defn- update-cv [cvp-user cv]
+  (let [import-json-url ((api :import-json) (:user_id cvp-user) (:default_cv_id cvp-user))]
+    (post-multipart import-json-url cv)))
+
+(defn- export-cv [db company-config person]
+  (let [cv (generate-cv db person)
+        email (:person/email-address person)
+        cvp-user (find-user-by-email email)]
+    (prn "Creating cv for " email)
+    (try (if cvp-user
+           (do
+             (cleanup-cv cvp-user)
+             (update-cv cvp-user cv))
+           (-> person
+               (generate-user company-config)
+               (create-or-update-user)
+               (update-cv cv)))
+         (str "Created cv for " email)
+         (catch Exception e
+           (str "Failed creating cv for " email)))))
+
+(defn export-all-cvs [db]
+  (let [company-config (get-company-config)]
+    (->> (find-all-persons db)
+         (filter #(not (:person/quit? %)))
+         (filter :person/profile-active?)
+         (drop 18)                                           ; TODO testing
+         (take 2)                                           ; TODO testing
+         (run! (partial export-cv db company-config)))))
+
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; REPL stuff
+(comment
+  (start)
+
+  (ns kodemaker-no.export.cvpartner)
+
+  ; datomic
+  (def conn (d/connect "datomic:mem://kodemaker"))
+  (def db (d/db conn))
+
+  ; All person ids
+  (d/q '[:find ?e :where [?e :person/full-name]] db)
+
+  ; Need company for create user
+  (http-get (api :companies))
+
+  ; trygve local here
+  (def trygve (d/pull db '[*] 17592186045673))
+
+  ; trygve cvpartner here
+  (find-user-by-email (:person/email-address trygve))
+  (http-get (str/join "/" [(api :users) "5ea84086af75491055e94423"]))
+
+  (generate-cv trygve)
+
+  (update-cv trygve)
+  (export-cv (get-company-config) 17592186045673)
+
+  (map str (export-all-cvs db))
+
+  ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+  ; Old stuff
+
+  ;
+  (d/q '[:find [(pull ?e [*]) ...] :where [?e :person/given-name "Trygve"]] db)
+  (d/q '[:find [(pull ?e [*]) ...] :where [?e :person/email-address "trygve@kodemaker.no"]] db)
+  ; NOT: (d/q '[:find [(pull ?e [*]) ...] :where [?e :id 17592186045673]] db)
+
+  )

--- a/src/kodemaker_no/export/cvpartner.clj
+++ b/src/kodemaker_no/export/cvpartner.clj
@@ -6,7 +6,7 @@
             [datomic-type-extensions.api :as d]
             [clojure.string :as str]
             [kodemaker-no.new-pages.cv-page :as page]
-            [kodemaker-no.new-pages.person :as person])
+            [kodemaker-no.new-pages.person :refer [prefer-techs]])
   (:import java.time.LocalDate))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -130,7 +130,7 @@
 (defn- pull-tech [db tech-ref]
   (db-pull-by-id db (:db/id tech-ref)))
 
-(defn all-techs-by-type [db person]
+(defn- all-techs-by-type [db person]
   "NOTE: Almost identical to page/all-techs, but still different"
   (->> (concat (:person/using-at-work person)
                (:person/innate-skills person)
@@ -140,7 +140,7 @@
                (page/presentation-techs person)
                (page/open-source-techs person)
                (page/project-techs person))
-       (remove (or (:person/exclude-techs person) #{}))
+       (remove (or (set (:person/exclude-techs person)) #{}))
        frequencies
        (sort-by (comp - second))
        (map first)

--- a/src/kodemaker_no/export/cvpartner.clj
+++ b/src/kodemaker_no/export/cvpartner.clj
@@ -119,6 +119,9 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ; cv data generation stuff
 
+(defn- trim-newlines [s]
+  (str/replace s #"\n\s+" "\n"))
+
 (defn- str-or-nil [label value]
   (if value
     (str label value)
@@ -158,9 +161,9 @@
    :organizer        {:no (:institution certification)}
    :long_description {:no (str/join "\n"
                                     (filter identity
-                                            [(str-or-nil "Url:" (:url certification))
-                                             (str-or-nil "Certificate-name:" (:text (:certificate certification)))
-                                             (str-or-nil "Certificate-url:" (:url (:certificate certification)))]))}
+                                            [(str-or-nil "Url: " (:url certification))
+                                             (str-or-nil "Certificate-name: " (:text (:certificate certification)))
+                                             (str-or-nil "Certificate-url: " (:url (:certificate certification)))]))}
    :year             (:year certification)})
 
 (defn- generate-education [education]
@@ -172,10 +175,10 @@
 (defn- generate-key-qualifications [db person]
   [
    {:label            {:no "Beskrivelse, person"}
-    :long_description {:no (:person/description person)}
+    :long_description {:no (trim-newlines (:person/description person))}
     :tag_line         {:no ""}}
    {:label            {:no "Beskrivelse, cv"}
-    :long_description {:no (:cv/description person)}
+    :long_description {:no (trim-newlines (:cv/description person))}
     :tag_line         {:no ""}}
    {:label            {:no "Nøkkelkvalifikasjoner"}
     :long_description {:no (:person/title person)}
@@ -212,7 +215,7 @@
 (defn- generate-project [db project]
   {:customer                  {:no (:project/customer project)}
    :description               {:no (:project/summary project)}
-   :long_description          {:no (:project/description project)}
+   :long_description          {:no (trim-newlines (:project/description project))}
    :year_from                 (first (:project/years project))
    :year_to                   (last (:project/years project))
    :project_experience_skills (generate-project-experience-skills db project)
@@ -222,11 +225,11 @@
   {:description      {:no (:presentation/title presentation)}
    :long_description {:no (str/join "\n"
                                     (filter identity
-                                            [(str-or-nil "Description:" (:presentation/description presentation))
-                                             (str-or-nil "Event-name:" (:presentation/event-name presentation))
-                                             (str-or-nil "Event-url:" (:presentation/event-url presentation))
-                                             (str-or-nil "Source-url:" (:presentation/source-url presentation))
-                                             (str-or-nil "Slides-url:" (:presentation/slides-url presentation))]))}
+                                            [(str-or-nil "Description: " (:presentation/description presentation))
+                                             (str-or-nil "Event-name: " (:presentation/event-name presentation))
+                                             (str-or-nil "Event-url: " (:presentation/event-url presentation))
+                                             (str-or-nil "Source-url: " (:presentation/source-url presentation))
+                                             (str-or-nil "Slides-url: " (:presentation/slides-url presentation))]))}
    :month            (.getMonthValue (:presentation/date presentation))
    :year             (.getYear (:presentation/date presentation))})
 

--- a/src/kodemaker_no/export/cvpartner.clj
+++ b/src/kodemaker_no/export/cvpartner.clj
@@ -111,6 +111,7 @@
       (delete-cv-part :certifications user-id cv-id)
       (delete-cv-part :educations user-id cv-id)
       (delete-cv-part :key_qualifications user-id cv-id)
+      (delete-cv-part :languages user-id cv-id)
       (delete-cv-part :presentations user-id cv-id)
       (delete-cv-part :project_experiences user-id cv-id)
       (delete-technologies user-id cv-id)
@@ -212,6 +213,13 @@
                      (:person/open-source-contributions person))}])
 
 
+(defn- generate-language [language]
+  {:name  {:no (:language language)}
+   :level {:no (str/join "\n"
+                         (filter identity
+                                 [(str-or-nil "Orally: " (:orally language))
+                                  (str-or-nil "Written: " (:written language))]))}})
+
 (defn- generate-project [db project]
   {:customer                  {:no (:project/customer project)}
    :description               {:no (:project/summary project)}
@@ -249,7 +257,7 @@
    :presentations       (map generate-presentation (:person/presentations person))
    :project_experiences (map (partial generate-project db) (:person/projects person))
    :technologies        (generate-technologies db person)
-   })
+   :languages           (map generate-language (:person/languages person))})
 
 (defn- generate-user [person company-config]
   {:country_id (:country-id company-config)

--- a/src/kodemaker_no/export/cvpartner.clj
+++ b/src/kodemaker_no/export/cvpartner.clj
@@ -121,7 +121,7 @@
 ; cv data generation stuff
 
 (defn- trim-newlines [s]
-  (str/replace s #"\n\s+" "\n"))
+  (if (nil? s) s (str/replace s #"\n\s+" "\n")))
 
 (defn- str-or-nil [label value]
   (if value

--- a/src/kodemaker_no/new_pages/cv_page.clj
+++ b/src/kodemaker_no/new_pages/cv_page.clj
@@ -40,7 +40,12 @@
    :security "Sikkerhet"
    :tool "Verktøy"
    :frontend "Frontend"
-   :cv/other "Annet"})
+   :cv/other "Annet"
+   :library "Bibliotek"
+   :framework "Rammeverk"
+   :specification "Spesifikasjoner"
+   :server "Server
+   "})
 
 (def tech-order
   [:proglang :devtools :vcs :methodology :os :database :devops :cloud :security :tool :frontend :cv/other])

--- a/test/kodemaker_no/export/cvpartner_test.clj
+++ b/test/kodemaker_no/export/cvpartner_test.clj
@@ -1,0 +1,24 @@
+(ns kodemaker-no.export.cvpartner-test
+  (:require [kodemaker-no.export.cvpartner :refer :all]
+            [midje.sweet :refer :all]))
+
+;(fact "Generates a simple cv"
+;      (generate-cv nil
+;        {:person/email-address "trygve@kodemaker.no"
+;         :person/projects      [{:project/customer    "Forsvaret"
+;                                 :project/summary     "Pif"
+;                                 :project/description "Paff"
+;                                 :project/years       [2019 2010]
+;                                 }]
+;
+;         })
+;      =>
+;           {:project_experiences [{:customer         {:no "Forsvaret"}
+;                                   :description      {:no "Pif"}
+;                                   :long_description {:no "Paff"}
+;                                   :year_from        2019
+;                                   :year_to          2010
+;                                   :disabled         false
+;                                   :project_experience_skills anything}]
+;            })
+

--- a/test/kodemaker_no/export/cvpartner_test.clj
+++ b/test/kodemaker_no/export/cvpartner_test.clj
@@ -1,24 +1,177 @@
 (ns kodemaker-no.export.cvpartner-test
   (:require [kodemaker-no.export.cvpartner :refer :all]
-            [midje.sweet :refer :all]))
+            [kodemaker-no.atomic :as atomic]
+            [kodemaker-no.content :as content]
+            [kodemaker-no.files :as files]
+            [kodemaker-no.ingest :as ingest]
+            [kodemaker-no.validate :refer [validate-content ID Person]]
+            [datomic-type-extensions.api :as d]
+            [midje.sweet :refer :all]
+            schema.core))
 
-;(fact "Generates a simple cv"
-;      (generate-cv nil
-;        {:person/email-address "trygve@kodemaker.no"
-;         :person/projects      [{:project/customer    "Forsvaret"
-;                                 :project/summary     "Pif"
-;                                 :project/description "Paff"
-;                                 :project/years       [2019 2010]
-;                                 }]
-;
-;         })
-;      =>
-;           {:project_experiences [{:customer         {:no "Forsvaret"}
-;                                   :description      {:no "Pif"}
-;                                   :long_description {:no "Paff"}
-;                                   :year_from        2019
-;                                   :year_to          2010
-;                                   :disabled         false
-;                                   :project_experience_skills anything}]
-;            })
+(defn- setup [conn]
+  (let [johndoe-filename "people/johndoe.edn"]
+    (doseq [file-name (files/find-file-names "resources/tech" #"(md|edn)$")]
+      (ingest/ingest conn (str "tech/" file-name)))
+    (ingest/ingest conn "tech-types.edn")
+    (ingest/ingest conn johndoe-filename)
+    (ingest/perform-last-minute-changes conn)
+    (let [person (content/slurp-edn-map (str "test/resources" "/" johndoe-filename))]
+      (schema.core/validate Person person))))
+
+(let [conn (atomic/create-database (str "datomic:mem://" (d/squuid)))]
+  (setup conn)
+  (let [db (d/db conn)
+        person (d/entity db (first (d/q '[:find [?e ...] :where [?e :person/email-address]] db)))
+        cv (generate-cv db person)]
+
+    (fact "Basic structure ok"
+          cv
+          =>
+          (just {:telefon             "+47 9206 1819"
+                 :twitter             "johndoe"
+                 :certifications      anything
+                 :educations          anything
+                 :key_qualifications  anything
+                 :languages           anything
+                 :presentations       anything
+                 :project_experiences anything
+                 :technologies        anything
+                 }))
+
+    (fact "certification ok"
+          (:certifications cv)
+          =>
+          (just [{:long_description {:no "Url: https://www.coursera.org/learn/introduction-tensorflow\nCertificate-name: Statements of Accomplishment\nCertificate-url: https://www.coursera.org/account/accomplishments/verify/ZSEZVPCC2MDS"}
+                  :name             {:no "Introduction to TensorFlow for Artificial Intelligence,,,"}
+                  :organizer        {:no "Deeplearning.ai / Coursera"}
+                  :year             2019}
+                 {:long_description {:no ""}
+                  :name             {:no "Certified ScrumMaster"}
+                  :organizer        {:no nil}
+                  :year             2006}])
+          :in-any-order)
+
+    (fact "educations ok"
+          (:educations cv)
+          =>
+          [{:degree    {:no "8 vekttall matematikk"}
+            :school    {:no "Universitet i Oslo"}
+            :year_from 1987
+            :year_to   1987}
+           {:degree    {:no "Bedriftsøkonomistudiet"}
+            :school    {:no "Handelshøyskolen BI"}
+            :year_from 1991
+            :year_to   1992}]
+          )
+
+    (fact "key_qualifications ok"
+          (:key_qualifications cv)
+          =>
+          (just [{:label            {:no "Beskrivelse, person"}
+                  :long_description {:no "\nJohn har lang og solid erfaring innen faget systemutvikling."}
+                  :tag_line         {:no ""}}
+                 {:label            {:no "Beskrivelse, cv"}
+                  :long_description {:no "John er entusiastisk opptatt av fagområdet systemutvikling..."}
+                  :tag_line         {:no ""}}
+                 {:key_points       [{:name {:no "Erfaring med forskjellige former for funksjonell programmering"}}
+                                     {:name {:no "Erfaring med moderne frontendutvikling med javascript, Typescript, React, Redux, CSS"}}]
+                  :label            {:no "Nøkkelkvalifikasjoner"}
+                  :long_description {:no "Systemutvikler"}}
+                 {:key_points [{:name {:no "TypeScript"}}
+                               {:name {:no "Groovy"}}]
+                  :label      {:no "Prefererte teknologier"}}
+                 {:key_points [{:name {:no "TypeScript"}}
+                               {:name {:no "React"}}
+                               {:name {:no "Redux"}}]
+                  :label      {:no "Bruker på jobben"}}
+                 {:key_points [{:name {:no "Reinforcement learning"}}]
+                  :label      {:no "Favoritter for tiden"}}
+                 {:key_points [{:name {:no "Tensorflow js"}}]
+                  :label      {:no "Vil lære mer av"}}
+                 {:key_points [{:long_description {:no "Url: https://github.com/grails/grails-core/commits?author=trygvea\nTechs: clojure.lang.LazySeq@753aa147"}
+                                :name             {:no "grails-core"}}]
+                  :label      {:no "Open source bidrag"}}
+                 ]
+                :in-any-order)
+          )
+
+    (fact "languages ok"
+          (:languages cv)
+          =>
+          []
+          )
+
+    (fact "presentations ok"
+          (:presentations cv)
+          =>
+          (just [{:description      {:no "Deep Learning / dyp læring"}
+                  :long_description {:no "Event-name: Kodemaker fagdag"}
+                  :month            5
+                  :year             2015}
+                 {:description      {:no "Groovy collection API"}
+                  :long_description {:no "Description: En oversikt over groovy's collection api\nEvent-name: Communities in Action\nSlides-url: http://www.slideshare.net/trygvea/groovy-collection-api-as-held-on-ci-a"}
+                  :month            2
+                  :year             2012}]
+                :in-any-order)
+          )
+
+    (fact "project_experiences ok"
+          (:project_experiences cv)
+          =>
+          (just [{:customer                  {:no "Forsvaret"}
+                  :description               {:no "PoC for innrapportering av materiell i skyen"}
+                  :disabled                  false
+                  :long_description          {:no "Laget et _Proof of Concept_..."}
+                  :project_experience_skills [{:tags {:no "React"}}
+                                              {:tags {:no "Redux"}}]
+                  :year_from                 2019
+                  :year_to                   2020}
+                 {:customer                  {:no "SAS"}
+                  :description               {:no "System for flyvedlikehold, m.fl."}
+                  :disabled                  false
+                  :long_description          {:no "Analyse og utvikling ..."}
+                  :project_experience_skills [{:tags {:no "C"}}
+                                              {:tags {:no "Plsql"}}]
+                  :year_from                 1989
+                  :year_to                   1994}
+                 {:customer                  {:no "Kolonial.no"}
+                  :description               {:no "Nytt terminalverktøy"}
+                  :disabled                  false
+                  :long_description          {:no "Utvikling av ny løsning..."}
+                  :project_experience_skills [{:tags {:no "TypeScript"}}
+                                              {:tags {:no "React"}}]
+                  :year_from                 2020
+                  :year_to                   2020}]
+                :in-any-order)
+          )
+
+    (fact "technologies ok"
+          (:technologies cv)
+          =>
+          (just [{:category          {:no "Programmeringsspråk"}
+                  :technology_skills [{:tags {:no "TypeScript"}}
+                                      {:tags {:no "Groovy"}}
+                                      {:tags {:no "Python"}}
+                                      {:tags {:no "C"}}
+                                      {:tags {:no "Prolog"}}
+                                      {:tags {:no "Pascal"}}]
+                  :uncategorized     false}
+                 {:category          {:no "Frontend"}
+                  :technology_skills [{:tags {:no "React"}}]
+                  :uncategorized     false}
+                 {:category          {:no "Metodikk"}
+                  :technology_skills [{:tags {:no "Maskinlæring"}}
+                                      {:tags {:no "Dyp læring"}}]
+                  :uncategorized     false}
+                 {:category          {:no "Bibliotek"}
+                  :technology_skills [{:tags {:no "Redux"}}]
+                  :uncategorized     false}
+                 {:category          {:no nil}
+                  :technology_skills [{:tags {:no "Plsql"}}
+                                      {:tags {:no "Fortran"}}
+                                      {:tags {:no "Dlib"}}]
+                  :uncategorized     true}]
+                :in-any-order)
+          )))
 

--- a/test/resources/people/johndoe.edn
+++ b/test/resources/people/johndoe.edn
@@ -1,0 +1,117 @@
+{:id                        :johndoe
+ :name                      ["John" "Doe"]
+ :title                     "Systemutvikler"
+ :start-date                "1997-02-01 00:00"
+ :description               "
+                             John har lang og solid erfaring innen faget systemutvikling."
+
+ :phone-number              "+47 9206 1819"
+ :email-address             "johndoe@kodemaker.no"
+
+ :presence                  {:cv       "johndoe"
+                             :twitter  "johndoe"
+                             :github   "johndoe"
+                             :linkedin "/in/johndoe"}
+
+ :tech                      {:using-at-work           [:react :redux :typescript]
+                             :favorites-at-the-moment [:reinforcement-learning]
+                             :want-to-learn-more      [:tensorflow-js]}
+
+ :innate-skills             [:pascal :prolog :fortran]
+
+ :recommendations           [{:title "Spinning up in Deep Reinforcement Learning"
+                              :blurb "Dette er stedet å grave seg dypt ned i RL."
+                              :link  {:url  "https://spinningup.openai.com"
+                                      :text "Sjekk ut nettstedet her"}
+                              :tech  [:machinelearning]}]
+
+ :side-projects             [{:title        "Fjesgjenkjenning"
+                              :description  "Bruke bilbioteket [dlib](http://blog.dlib.net) til å kjenne igjen alle kodemakere"
+                              :link         {:url "https://github.com/trygvea/face-recognition-dlib" :text "Se koden her"}
+                              :illustration "/illustrations/side-projects/trygve-og-einar.png"
+                              :tech         [:python :dlib :machinelearning]
+                              }]
+
+ :hobbies                   [{:title        "Maskinlæring"
+                              :description  "De siste årene har jeg hatt spesiellt fokus på maskinlæring."
+                              :illustration "/photos/tech/machinelearning.jpg"}]
+
+ :presentations             [{:title "Groovy collection API"
+                              :blurb "En oversikt over groovy's collection api"
+                              :tech  [:groovy]
+                              :event "Communities in Action"
+                              :date  "2012-02-01"
+                              :urls  {:slides "http://www.slideshare.net/trygvea/groovy-collection-api-as-held-on-ci-a"}}]
+
+ :appearances               [{:title "Deep Learning / dyp læring"
+                              :event "Kodemaker fagdag"
+                              :tech  [:deeplearning :machinelearning]
+                              :date  "2015-05-21"}
+                             ]
+
+ :open-source-projects      [{:url         "http://grails.org/plugin/class-diagram"
+                              :name        "Grails class diagram plugin"
+                              :description "The ClassDiagram plugin provides an UML-like diagram of your grails domain classes."
+                              :tech        [:groovy :grails]}]
+
+ :open-source-contributions [{:name "grails-core", :url "https://github.com/grails/grails-core/commits?author=trygvea", :tech [:grails]}]
+
+ :project-highlights        [{:blurb    "Utvikling av media-arkivet til NRK. Frontend med React, Redux, Typescript"
+                              :customer "Nrk"}
+                             {:blurb    "Ny og innovativ meglerløsning. Frontend med React/Redux."
+                              :customer "BN Bolig"}
+                             {:blurb    "Distribusjon av fremskrevne tidsserier for forskjellige markeder. Spark, Kafka, HBase"
+                              :customer "Thomson Reuters"}]
+
+ :projects                  [{:customer    "Kolonial.no"
+                              :years       [2020]
+                              :employer    :kodemaker
+                              :summary     "Nytt terminalverktøy"
+                              :description "Utvikling av ny løsning..."
+                              :tech        [:react :typescript]}
+                             {:customer    "Forsvaret"
+                              :years       [2019 2020]
+                              :employer    :kodemaker
+                              :summary     "PoC for innrapportering av materiell i skyen"
+                              :description "Laget et _Proof of Concept_..."
+                              :tech        [:react :redux]}
+                             {:customer              "SAS"
+                              :years                 [1989 1990 1991 1992 1993 1994]
+                              :exclude-from-profile? true
+                              :employer              :sas-data
+                              :summary               "System for flyvedlikehold, m.fl."
+                              :description           "Analyse og utvikling ..."
+                              :tech                  [:plsql :c]}]
+
+ :cv                        {:default {:preferred-techs [
+                                                         :typescript :groovy]
+                                       :exclude-techs   []}}
+
+ :cv/description            "John er entusiastisk opptatt av fagområdet systemutvikling..."
+
+ :education-summary         "Ingeniør fra Kongsberg Ingeniørhøgskole..."
+ :experience-since          1984
+ :qualifications            ["Erfaring med moderne frontendutvikling med javascript, Typescript, React, Redux, CSS"
+                             "Erfaring med forskjellige former for funksjonell programmering"]
+ :certifications            [{:institution "Deeplearning.ai / Coursera"
+                              :name        "Introduction to TensorFlow for Artificial Intelligence,,,"
+                              :url         "https://www.coursera.org/learn/introduction-tensorflow"
+                              :year        2019
+                              :certificate
+                                           {:url  "https://www.coursera.org/account/accomplishments/verify/ZSEZVPCC2MDS"
+                                            :text "Statements of Accomplishment"}}
+                             {:name "Certified ScrumMaster", :year 2006}]
+ :relationship-status       "Gift, 2 barn"
+ :born                      1961
+ :education                 [{:institution "Handelshøyskolen BI"
+                              :years       [1991 1992]
+                              :subject     "Bedriftsøkonomistudiet"}
+                             {:institution "Universitet i Oslo"
+                              :years       [1987]
+                              :subject     "8 vekttall matematikk"}]
+
+ :endorsement-highlight     {:author "Ståle Bie"
+                             :title  "Avdelingsleder, SAS Data"
+                             :quote  "Han storkoser seg når det umulige blir mulig og skyr ingen anstrengelser.
+                                Samtidig klarer han å beholde målet i fokus, en hardtslående kombinasjon!"}
+ }


### PR DESCRIPTION
På oppdrag fra Kolbjørn så skal vi altså eksportere cv-er til cvpartner.no.
De er enda ikke helt klare på sin side, så 2/3 av cv-ene timer ut etter et minutt eller så. De har lovet at dette skal gå bra så vi bare krysser fingrene.

Hovedtrekk i løsningen er som følger: Man starter eksport via et shell script. Man må sette opp hemmeligheter først, der har jeg laget et lite opplegg, se secret-sample.envrc.
Api-et til cvpartner gir noen føringer på implementasjon. Man må slette eksisterende cv, del for del, før man POSTer den nye cv-en. Api dok finnes her: https://kodemaker.cvpartner.com/help/api, men man må ha login for å se den (ikke bra). Si fra så kan vi sikkert ordne flere logins.

Det var vanskelig å finne noe å teste som ikke er knyttet til enten datomic spørringer eller cvpartner api. Jeg har ikke lyst til å mocke noen av disse. Mulig det er noe lys jeg ikke har sett her :) 

Som den clojure n00b jeg er, så jeg er åpen for mye rødt blekk i pr-en :) 