### PR TITLE
vise kodemakere på tech-sidene

### DIFF
--- a/src/kodemaker_no/atomic.clj
+++ b/src/kodemaker_no/atomic.clj
@@ -52,7 +52,7 @@
                   :page.kind/cv (cv-page/create-page e)
                   :page.kind/reference (reference-page/create-page e)
                   :page.kind/references (references-page/create-page e)
-                  :page.kind/tech (tech-page/create-page e)
+                  :page.kind/tech (tech-page/create-page db e)
                   :page.kind/people (people-page/create-page e)
                   :page.kind/video (video-page/create-page e)
                   :page.kind/whoami (whoami-page/create-page e))

--- a/src/kodemaker_no/new_pages/tech_page.clj
+++ b/src/kodemaker_no/new_pages/tech_page.clj
@@ -268,7 +268,8 @@
     (and [?e :person/open-source-projects ?x] [?x :oss-project/techs ?tech-ref])
     (and [?e :person/workshops ?x] [?x :presentation-product/techs ?tech-ref])
     (and [?e :person/business-presentations ?x] [?x :presentation-product/techs ?tech-ref])
-  )] db (:db/id tech))
+    (and [?x :blog-post/techs ?tech-ref] [?x :blog-post/author ?e])
+)] db (:db/id tech))
     (map #(d/entity db %)) 
     seq)]
     {:kind :titled

--- a/src/kodemaker_no/new_pages/tech_page.clj
+++ b/src/kodemaker_no/new_pages/tech_page.clj
@@ -259,7 +259,19 @@
                               :link {:text (format "Se flere skriverier om %s" (:tech/name tech))
                                      :href url}}))]))}))
 
-(defn create-page [tech]
+(defn people-section [tech db]
+  (when-let [people (->> (d/q '[:find [?e ...] :in $ ?tech-ref :where [?e :person/projects ?proj] [?proj :project/techs ?tech-ref]] db (:db/id tech))
+                         (map #(d/entity db %)))]
+    {:kind :titled
+     :title "Våre ansatte med denne kompetansen"
+     :contents [(e/tango-grid (for [person people]
+                                {:content
+                                 (e/illustrated
+                                  {:image (str "/vcard-small" (first (:person/portraits person)))
+                                   :title (:person/full-name person)
+                                   :href (:page/uri person)})}))]}))
+
+(defn create-page [db tech]
   (let [presentations (classify-presentations tech)]
     {:title (:tech/name tech)
      :sections
@@ -291,6 +303,7 @@
        (side-projects-section tech)
        (open-source-section tech)
        (blog-post-section tech)
+       (people-section tech db)
        {:kind :footer}]
       (remove nil?)
       (map (fn [color section]

--- a/src/kodemaker_no/new_pages/tech_page.clj
+++ b/src/kodemaker_no/new_pages/tech_page.clj
@@ -301,7 +301,7 @@
                                          {:image (str "/vcard-small" (first (:person/portraits person)))
                                           :href (:page/uri person)
                                           :lines [(:person/given-name person)]})}))]
-                 [(e/teaser {:link {:text "Alle ansatte"
+                 [(e/teaser {:link {:text "Stort sett alle"
                                     :href "/folk/"}})])}))
 
 (defn create-page [db tech]

--- a/src/kodemaker_no/new_pages/tech_page.clj
+++ b/src/kodemaker_no/new_pages/tech_page.clj
@@ -265,12 +265,12 @@
                          seq)]
     {:kind :titled
      :title (format "Vi kan %s" (:tech/name tech))
-     :contents [(e/tango-grid (for [person people]
-                                {:content
-                                 (e/illustrated
-                                  {:image (str "/vcard-small" (first (:person/portraits person)))
-                                   :title (:person/full-name person)
-                                   :href (:page/uri person)})}))]}))
+     :contents [(e/round-card-grid (for [person people]
+                                     {:content
+                                      (e/centered-vert-round-media
+                                       {:image (str "/vcard-small" (first (:person/portraits person)))
+                                        :href (:page/uri person)
+                                        :lines [(:person/given-name person)]})}))]}))
 
 (defn create-page [db tech]
   (let [presentations (classify-presentations tech)]
@@ -297,14 +297,13 @@
                 :position "top -410px right 60vw"}
                {:kind :dotgrid
                 :position "top -110px left 80vw"}]}
-
+       (people-section tech db)
        (recommendations-section tech)
        (presentations-section presentations)
        (screencasts-section tech)
        (side-projects-section tech)
        (open-source-section tech)
        (blog-post-section tech)
-       (people-section tech db)
        {:kind :footer}]
       (remove nil?)
       (map (fn [color section]

--- a/src/kodemaker_no/new_pages/tech_page.clj
+++ b/src/kodemaker_no/new_pages/tech_page.clj
@@ -261,7 +261,8 @@
 
 (defn people-section [tech db]
   (when-let [people (->> (d/q '[:find [?e ...] :in $ ?tech-ref :where [?e :person/projects ?proj] [?proj :project/techs ?tech-ref]] db (:db/id tech))
-                         (map #(d/entity db %)))]
+                         (map #(d/entity db %))
+                         seq)]
     {:kind :titled
      :title "Våre ansatte med denne kompetansen"
      :contents [(e/tango-grid (for [person people]

--- a/src/kodemaker_no/new_pages/tech_page.clj
+++ b/src/kodemaker_no/new_pages/tech_page.clj
@@ -264,7 +264,7 @@
                          (map #(d/entity db %))
                          seq)]
     {:kind :titled
-     :title "Våre ansatte med denne kompetansen"
+     :title (format "Vi kan %s" (:tech/name tech))
      :contents [(e/tango-grid (for [person people]
                                 {:content
                                  (e/illustrated

--- a/src/kodemaker_no/new_pages/tech_page.clj
+++ b/src/kodemaker_no/new_pages/tech_page.clj
@@ -260,9 +260,17 @@
                                      :href url}}))]))}))
 
 (defn people-section [tech db]
-  (when-let [people (->> (d/q '[:find [?e ...] :in $ ?tech-ref :where [?e :person/projects ?proj] [?proj :project/techs ?tech-ref]] db (:db/id tech))
-                         (map #(d/entity db %))
-                         seq)]
+  (when-let [people (->> (d/q '[:find [?e ...] :in $ ?tech-ref :where 
+    (or (and [?e :person/projects ?x] [?x :project/techs ?tech-ref])
+    (and [?e :person/side-projects ?x] [?x :side-project/techs ?tech-ref])
+    (and [?e :person/presentations ?x] [?x :presentation/techs ?tech-ref])
+    (and [?e :person/screencasts ?x] [?x :screencast/techs ?tech-ref])
+    (and [?e :person/open-source-projects ?x] [?x :oss-project/techs ?tech-ref])
+    (and [?e :person/workshops ?x] [?x :presentation-product/techs ?tech-ref])
+    (and [?e :person/business-presentations ?x] [?x :presentation-product/techs ?tech-ref])
+  )] db (:db/id tech))
+    (map #(d/entity db %)) 
+    seq)]
     {:kind :titled
      :title (format "Vi kan %s" (:tech/name tech))
      :contents [(e/round-card-grid (for [person people]
@@ -297,13 +305,13 @@
                 :position "top -410px right 60vw"}
                {:kind :dotgrid
                 :position "top -110px left 80vw"}]}
-       (people-section tech db)
        (recommendations-section tech)
        (presentations-section presentations)
        (screencasts-section tech)
        (side-projects-section tech)
        (open-source-section tech)
        (blog-post-section tech)
+       (people-section tech db)
        {:kind :footer}]
       (remove nil?)
       (map (fn [color section]

--- a/ui/resources/public/css/kodemaker.css
+++ b/ui/resources/public/css/kodemaker.css
@@ -976,7 +976,7 @@ a, .clickable {
   border-color: var(--chocolat-au-lait);
 }
 
-@media only screen and (max-width: 899px) {
+@media only screen and (max-width: 900px) {
   .titled-title { margin-bottom: 64px; }
   .definition-title { margin-bottom: 16px; }
 }
@@ -1125,6 +1125,16 @@ a, .clickable {
   .vert-round-media {flex-direction: column; align-items: flex-start;}
   .vert-round-media .media-element {margin-bottom: 16px;}
 }
+
+.centered-vert-round-media {flex-direction: column; align-items: center;}
+.round-media.media {display: flex;}
+.centered-vert-round-media .media-element {margin-right: 0px; margin-bottom: 16px;}
+.centered-vert-round-media .media-content p {text-align: center;}
+
+@media only screen and (min-width: 600px) {
+  .centered-vert-round-media .media-element .img {max-width: 240px;}
+}
+
 
 .illustrated {flex-direction: column; align-items: flex-start;}
 .illustrated .media-element {margin-bottom: 32px;}
@@ -1286,6 +1296,13 @@ a, .clickable {
   .card-grid-item {
     margin-bottom: 64px;
   }
+}
+
+.round-card-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  grid-gap: 0px 8%;
+  justify-content: space-between;
 }
 
 @media only screen and (min-width: 600px) {

--- a/ui/src/ui/elements.cljc
+++ b/ui/src/ui/elements.cljc
@@ -170,6 +170,14 @@
                         :type "vcard-medium"
                         :size 120})))
 
+(defn centered-vert-round-media [params]
+  (media (assoc params
+                :class "round-media vert-round-media centered-vert-round-media"
+                :content [:p (interpose [:br] (:lines params))]
+                :image {:src (:image params)
+                        :type "vcard-medium"
+                        :size 240})))
+
 (defn illustrated [params]
   (media (assoc params
                 :class "illustrated"
@@ -248,6 +256,11 @@
 
 (defn card-grid [items]
   [:div.card-grid
+   (for [{:keys [content]} items]
+     [:div.card-grid-item content])])
+
+(defn round-card-grid [items]
+  [:div.card-grid.round-card-grid
    (for [{:keys [content]} items]
      [:div.card-grid-item content])])
 


### PR DESCRIPTION
Har gjort en liten endring på tech-sidene og lagt på bilder og navn på de som har den tech listet på kundeprosjekter. Foreløpig uten sortering og kun kundeprosjekter. Kom gjerne med feedback! Bør lista sorteres på noe vis? Skal vi trekke ut tech fra side-prosjekter, bloggposter etc.? Skal vi vise alle eller begrense til et antall? Kan bli litt mange på feks clojure siden. 

Kan testes på alle tech-sider, men her er noen eksempler: 
https://3e80-84-214-187-118.ngrok.io/flutter/
https://3e80-84-214-187-118.ngrok.io/clojure/ 
https://3e80-84-214-187-118.ngrok.io/java/ 
