### PR TITLE
firmablogg: deklarer z.infer<T> som typealias.

### DIFF
--- a/resources/firmablogg/2023-03-15-deklarative-json-validation.md
+++ b/resources/firmablogg/2023-03-15-deklarative-json-validation.md
@@ -70,7 +70,7 @@ const CardSchema = z.object({
 });
 
 // 2 - Utled type basert på skjema
-const Card = z.infer<typeof CardSchema>;
+type Card = z.infer<typeof CardSchema>;
 ```
 
 Nå har du et skjema du kan bruke for å parse og validere json og du har en type utledet fra skjema som har samme form som i forrige eksempel.
@@ -99,10 +99,10 @@ Dersom validering feiler får du en et feilobjekt `error` i resultatet fra parsi
 // 1. Modellere enums
 
 const SuitSchema = z.enum(["Hearts", "Spades", "Clubs", "Diamonds"]);
-const Suit = z.infer<typeof SuitSchema>;
+type Suit = z.infer<typeof SuitSchema>;
 
 const RankSchema = z.enum(["Ace", "2", "3", "4", "5", "6", "7", "8", "9", "10", "Jack", "Queen", "King"]);
-const Rank = z.infer<typeof RankSchema>;
+type Rank = z.infer<typeof RankSchema>;
 
 // 2. Forbedre CardSchema til å sjekke at kun gyldige enum verdier er brukt 
 const CardSchema = z.object({


### PR DESCRIPTION
Hallois!

Vet ikke om det er helt uhørt at en ekstern oppretter PR-er i dette repoet, men jeg lar det stå til: jeg satt og prøvde å reprodusere kodesnuttene i @rundis' JSON-valideringsartikkel, men IDE-en min begynte ganske raskt å brøle. Problemet er som følger:

`z.infer<T>` gir ikke en verdi, men et typealias, ergo må man deklarere deretter, ellers blir LSP-er osv. lei seg. Eksempelvis gir `const Card = z.infer<typeof cardSchema>;` følgende feilmelding hos meg: «Property 'infer' does not exist on type 'typeof import("https://deno.land/x/zod@v.3.21.4/external")' ». Når man så prøver å bruke den som type, f.eks. `let aCard: Card`, får man et hint om at noe er galt: «'Card' refers to a value, but is being used as a type here. Did you mean 'typeof Card?»

Litt på si (og noe jeg ikke har fikset i PR-en): jeg synes det var smått forvirrende at `schema.safeParse()` ikke faktisk opererer på JSON i strengform, men snarere konstruerte objekter. Ettersom artikkelen begynner med eksempelet ```const aCard: Card = JSON.parse(`{"suit": "hearts", "rank": 1}`);```, for så å gjøre `const res = CardSchema.safeParse(json);`, uten å si hva `json` er (JSON-streng eller resultat av `JSON.parse()`?), tenkte jeg at `safeParse()` også konstruerte objektet som skal valideres, men det stemmer jo ikke; for at valideringen skal funke, må man gjøre `CardSchema.safeParse(JSON.parse(…))`.

Sånn, dett var dett, håper dette ikke er til bry; god fredag :–)